### PR TITLE
Update build to babel 7 and configure to compile to modern targets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,18 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    [
+      "@babel/preset-env", 
+      {
+        "targets": {
+          "node": "8.11",
+          "browsers": [
+            "Firefox 57",
+            "Chrome 60",
+            "iOS 10",
+            "Safari 10"
+          ]
+        }
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -3,24 +3,19 @@
   "version": "1.1.0",
   "description": "A state machine compiler",
   "main": "index.js",
-  "dependencies": {
-    "babel-runtime": "^6.11.6"
-  },
   "devDependencies": {
-    "babel-core": "^6.17.0",
-    "babel-plugin-transform-runtime": "^6.15.0",
-    "babel-polyfill": "^6.16.0",
-    "babel-preset-es2015": "^6.16.0",
-    "babel-register": "^6.16.3",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "mocha": "^3.1.0",
     "pegjs": "^0.10.0",
-    "rollup": "^0.36.1",
-    "rollup-plugin-babel": "^2.6.1",
-    "rollup-plugin-commonjs": "^5.0.4",
+    "rollup": "^1.5.0",
+    "rollup-plugin-babel": "^4.0.1",
+    "rollup-plugin-commonjs": "^9.2.1",
     "rollup-plugin-local-resolve": "^1.0.7"
   },
   "scripts": {
-    "test": "mocha --require babel-register --require babel-polyfill",
+    "test": "mocha --require @babel/register",
     "prepublish": "make"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,16 +2,32 @@ import babel from 'rollup-plugin-babel';
 import localResolve from 'rollup-plugin-local-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 
-export default {
-  format: 'cjs',
+export default {  
+  output: {
+    format: 'cjs',
+    sourcemap: true
+  },
   plugins: [
     localResolve(),
     commonjs(),
     babel({
-      babelrc: false,
-      presets: [['es2015', { modules: false }]],
-      plugins: ['transform-runtime'],
-      runtimeHelpers: true
+      presets: [
+        [
+          '@babel/preset-env', 
+          {
+            modules: false,
+            targets: {
+              node: '8.11',
+              browsers: [
+                'Firefox 57',
+                'Chrome 60',
+                'iOS 10',
+                'Safari 10'
+              ]
+            }
+          }
+        ]
+      ]
     })
   ]
 };


### PR DESCRIPTION
This updates the build system to use babel 7 and configure it to target modern systems.

Removes the dependency of babel-runtime specially the generator one, which is a big one