### PR TITLE
Restore IE11 compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,7 @@
           ]
         },
         "corejs": 3,
-        "useBuiltIns": "entry"
+        "useBuiltIns": "usage"
       }
     ]
   ]

--- a/.babelrc
+++ b/.babelrc
@@ -9,9 +9,12 @@
             "Firefox 57",
             "Chrome 60",
             "iOS 10",
-            "Safari 10"
+            "Safari 10",
+            "IE 11"
           ]
-        }
+        },
+        "corejs": 3,
+        "useBuiltIns": "entry"
       }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "pegjs": "^0.10.0",
     "rollup": "^1.5.0",
     "rollup-plugin-babel": "^4.0.1",
-    "rollup-plugin-commonjs": "^9.2.1",
-    "rollup-plugin-local-resolve": "^1.0.7"
+    "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-node-resolve": "^5.2.0"
   },
   "scripts": {
     "test": "mocha --require @babel/register",
@@ -38,5 +38,9 @@
     "index.js.map",
     "compile.js",
     "compile.js.map"
-  ]
+  ],
+  "dependencies": {
+    "core-js": "^3.2.1",
+    "regenerator-runtime": "^0.13.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "test": "mocha --require @babel/register",
-    "prepublish": "make"
+    "prepare": "make"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import babel from 'rollup-plugin-babel';
-import localResolve from 'rollup-plugin-local-resolve';
+import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 
 export default {  
@@ -8,7 +8,7 @@ export default {
     sourcemap: true
   },
   plugins: [
-    localResolve(),
+    resolve(),
     commonjs(),
     babel({
       presets: [
@@ -22,7 +22,8 @@ export default {
                 'Firefox 57',
                 'Chrome 60',
                 'iOS 10',
-                'Safari 10'
+                'Safari 10',
+                'IE 11'
               ]
             }
           }

--- a/src/dfa.js
+++ b/src/dfa.js
@@ -1,4 +1,3 @@
-import "core-js/stable";
 import "regenerator-runtime/runtime";
 
 import {EndMarker, Concatenation, Literal, Tag} from './nodes';

--- a/src/dfa.js
+++ b/src/dfa.js
@@ -1,3 +1,6 @@
+import "core-js/stable";
+import "regenerator-runtime/runtime";
+
 import {EndMarker, Concatenation, Literal, Tag} from './nodes';
 import {addAll, equal} from './utils';
 


### PR DESCRIPTION
This PR restores IE11 compatibility by adding that browser to Babel presets and including core-js and regenerator-runtime. This configuration provides roughly the build setup that we had prior to eed4375769420543bf8d98bdb5190aec989811e6, but it runs on the latest version of Babel and avoids deprecated options. (I've also added Safari 10 to the compatibility list for the sake of completeness.)

This PR resolves #2. I've tested locally with an affected project and `npm link`, and this change does solve the problem for me.

I've also replaced the [deprecated](https://docs.npmjs.com/misc/scripts#prepublish-and-prepare) `prepublish` script with `prepare`. This change should make it easier to test this change by installing from a fork on GitHub.

Thank you in advance for taking a look at this PR! 😄 